### PR TITLE
Modify PatchACPI to assign processorIDs from DSDT

### DIFF
--- a/rEFIt_UEFI/Platform/AcpiPatcher.c
+++ b/rEFIt_UEFI/Platform/AcpiPatcher.c
@@ -1718,7 +1718,6 @@ EFI_STATUS PatchACPI(IN REFIT_VOLUME *Volume, CHAR8 *OSVersion)
   BOOLEAN           DsdtLoaded = FALSE;
   BOOLEAN           NeedUpdate = FALSE;
   OPER_REGION       *tmpRegion;
-  INTN              ApicCPUBase = 0;
   CHAR16*           AcpiOemPath = PoolPrint(L"%s\\ACPI\\patched", OEMPath);
 
   DbgHeader("PatchACPI");
@@ -2128,12 +2127,6 @@ EFI_STATUS PatchACPI(IN REFIT_VOLUME *Volume, CHAR8 *OSVersion)
     ApicTable = (EFI_ACPI_DESCRIPTION_HEADER*)(UINTN)(*xf);
     //      ApicLen = ApicTable->Length;
     ProcLocalApic = (EFI_ACPI_2_0_PROCESSOR_LOCAL_APIC_STRUCTURE *)(UINTN)(*xf + sizeof(EFI_ACPI_2_0_MULTIPLE_APIC_DESCRIPTION_TABLE_HEADER));
-    //determine first ID of CPU. This must be 0 for Mac and for good Hack
-    // but = 1 for stupid ASUS
-    //
-    if (ProcLocalApic->Type == EFI_ACPI_4_0_PROCESSOR_LOCAL_APIC) {
-      ApicCPUBase = ProcLocalApic->AcpiProcessorId; //we want first instance
-    }
 
     while ((ProcLocalApic->Type == EFI_ACPI_4_0_PROCESSOR_LOCAL_APIC) && (ProcLocalApic->Length == 8)) {
       if (ProcLocalApic->Flags & EFI_ACPI_4_0_LOCAL_APIC_ENABLED) {
@@ -2150,7 +2143,7 @@ EFI_STATUS PatchACPI(IN REFIT_VOLUME *Volume, CHAR8 *OSVersion)
       ApicCPUNum = gCPUStructure.Threads;
     }
 
-    DBG("ApicCPUBase=%d ApicCPUNum=%d\n", ApicCPUBase, ApicCPUNum);
+    DBG("ApicCPUNum=%d\n", ApicCPUNum);
     //reallocate table
     if (gSettings.PatchNMI) {
       BufferPtr = EFI_SYSTEM_TABLE_MAX_ADDRESS;
@@ -2198,11 +2191,11 @@ EFI_STATUS PatchACPI(IN REFIT_VOLUME *Volume, CHAR8 *OSVersion)
           for (Index = 0; Index < ApicCPUNum; Index++) {
             LocalApicNMI->Type = EFI_ACPI_4_0_LOCAL_APIC_NMI;
             LocalApicNMI->Length = sizeof(EFI_ACPI_4_0_LOCAL_APIC_NMI_STRUCTURE);
-            LocalApicNMI->AcpiProcessorId = (UINT8)(ApicCPUBase + Index);
+            LocalApicNMI->AcpiProcessorId = acpi_cpu_processor_id[Index];
             LocalApicNMI->Flags = 5;
             LocalApicNMI->LocalApicLint = 1;
             LocalApicNMI++;
-            ApicTable->Length += LocalApicNMI->Length;
+            ApicTable->Length += sizeof(EFI_ACPI_4_0_LOCAL_APIC_NMI_STRUCTURE);
           }
           DBG("ApicTable new Length=%d\n", ApicTable->Length);
           // insert corrected MADT

--- a/rEFIt_UEFI/Platform/FixBiosDsdt.c
+++ b/rEFIt_UEFI/Platform/FixBiosDsdt.c
@@ -1036,6 +1036,7 @@ VOID findCPU(UINT8* dsdt, UINT32 length)
       if (add_name) {
         acpi_cpu_name[acpi_cpu_count] = AllocateZeroPool(5);
         CopyMem(acpi_cpu_name[acpi_cpu_count], dsdt+offset, 4);
+        acpi_cpu_processor_id[acpi_cpu_count] = dsdt[offset + 4];
         i = offset + 5;
 
                 //if (acpi_cpu_count == 0)
@@ -1046,7 +1047,7 @@ VOID findCPU(UINT8* dsdt, UINT32 length)
         } else {
             DBG("| %a ", acpi_cpu_name[acpi_cpu_count]);
         }
-        if (++acpi_cpu_count == 32)
+        if (++acpi_cpu_count == acpi_cpu_max)
             break;
       }
     }
@@ -1057,6 +1058,7 @@ VOID findCPU(UINT8* dsdt, UINT32 length)
     for (i=0; i<15; i++) {
       acpi_cpu_name[i] = AllocateZeroPool(5);
       AsciiSPrint(acpi_cpu_name[i], 5, "CPU%1x", i);
+      acpi_cpu_processor_id[i] = i;
     }
   }
   return;

--- a/rEFIt_UEFI/Platform/Platform.h
+++ b/rEFIt_UEFI/Platform/Platform.h
@@ -1674,8 +1674,10 @@ extern UINT8                            DefaultAudioVolume;
 //CHAR8*   orgBiosDsdt;
 extern UINT64                          BiosDsdt;
 extern UINT32                          BiosDsdtLen;
+#define                                acpi_cpu_max 128
 extern UINT8                           acpi_cpu_count;
 extern CHAR8                           *acpi_cpu_name[];
+extern UINT8                           acpi_cpu_processor_id[];
 extern CHAR8                           *acpi_cpu_score;
 extern BOOLEAN                         SSSE3;
 extern BOOLEAN                         defDSM;

--- a/rEFIt_UEFI/Platform/StateGenerator.c
+++ b/rEFIt_UEFI/Platform/StateGenerator.c
@@ -6,8 +6,6 @@
 #include "StateGenerator.h"
 
 
-//CHAR8* acpi_cpu_name[] = {"CPU0", "CPU1", "CPU2", "CPU3", "CPU4", "CPU5", "CPU6", "CPU7", "CPU8", "CPU9"};
-
 CONST UINT8 pss_ssdt_header[] =
 {
   0x53, 0x53, 0x44, 0x54, 0x7E, 0x00, 0x00, 0x00, /* SSDT.... */


### PR DESCRIPTION
MacOS assumes that the first processor from DSDT is always enabled, without checking MADT table.
Here we're trying to assign first IDs found in DSDT to enabled processors in MADT, such that macOS assumption to be true.

--------------------
This change should fix some X79 boards with strange DSDT: https://pastebin.com/raw/SZRn1BGj (cpu: 80, 81, 00, 01, .... 0f, 82....).
Now whatever is present in DSDT should be mirrored to MADT.
