### PR TITLE
Reduce the number of folders created outside of Clover folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .cache
 Conf/.cache
 Conf/target.txt
+toolchain/
 
 # /CloverPackage/
 /CloverPackage/sym/

--- a/buildme
+++ b/buildme
@@ -13,9 +13,8 @@
 
 cd "$(dirname $([ -L $0 ] && readlink $0 || echo $0))"
 declare -r CLOVERROOT="$PWD"
+declare -r SYSNAME="$(uname)"
 MYTOOLCHAIN=${1:-GCC53}
-
-TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-$(dirname $CLOVERROOT)/opt/local}
 
 # Functions
 pathmunge() {
@@ -57,13 +56,16 @@ fi
 }
 
 exportPaths() {
-if [[ "$(uname)" == Darwin ]]; then
+if [[ "$SYSNAME" == Linux ]]; then
+  TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-/usr}
+elif [[ "$SYSNAME" == Darwin ]]; then
   pathmunge "$(xcode-select --print-path)"/usr/bin
+  TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-"$CLOVERROOT"/toolchain}
 fi
 
 pathmunge "$TOOLCHAIN_DIR"/bin
 export TOOLCHAIN_DIR=$TOOLCHAIN_DIR
-export DIR_MAIN=${DIR_MAIN:-$(dirname $CLOVERROOT)}
+export DIR_MAIN=${DIR_MAIN:-"$CLOVERROOT"/toolchain}
 export DIR_TOOLS=${DIR_TOOLS:-$DIR_MAIN/tools}
 export DIR_DOWNLOADS=${DIR_DOWNLOADS:-$DIR_TOOLS/download}
 export DIR_LOGS=${DIR_LOGS:-$DIR_TOOLS/logs}
@@ -72,7 +74,7 @@ export PREFIX=${TOOLCHAIN_DIR}
 
 checkTools() {
 # export any env vars before building anything
-if [[ "$(uname)" == Darwin ]]; then
+if [[ "$SYSNAME" == Darwin ]]; then
   checkXCODE
   exportPaths
   local GCC53_BIN="$PREFIX/cross/bin/x86_64-clover-linux-gnu-gcc"
@@ -163,7 +165,7 @@ echo "[BUILD CLOVER TEST]"
 }
 
 buildPkg() {
-if [[ "$(uname)" == Darwin ]]; then
+if [[ "$SYSNAME" == Darwin ]]; then
   cd "${CLOVERROOT}"/CloverPackage
   echo "[BUILD PKG]"
   checkXCODE
@@ -175,7 +177,7 @@ fi
 }
 
 buildApp() {
-if [[ "$(uname)" == Darwin ]]; then
+if [[ "$SYSNAME" == Darwin ]]; then
   if [[ -f "${CLOVERROOT}"/CloverPackage/CloverV2/EFI/CLOVER/CLOVERX64.efi ]]; then
     cd "${CLOVERROOT}"/CloverApp
     echo "[BUILD APP]"

--- a/ebuild.sh
+++ b/ebuild.sh
@@ -33,7 +33,7 @@ PLATFORMFILE=
 MODULEFILE=
 TARGETRULE=
 
-SCRIPT_VERS="2019-09-06"
+SCRIPT_VERS="2019-11-09"
 
 # Macro
 M_NOGRUB=0
@@ -54,10 +54,12 @@ if [[ "$SYSNAME" == Linux ]]; then
   export TOOLCHAIN=GCC53
   TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-/usr}
 else
-  TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-"$CLOVERROOT"/../../toolchain}
-fi
-if [[ ! -d $TOOLCHAIN_DIR ]]; then
-  TOOLCHAIN_DIR="${PWD}"/../opt/local
+  if [[ -d ~/src/opt/local ]]; then
+    TOOLCHAIN_DIR=~/src/opt/local
+  else
+    TOOLCHAIN_DIR=${TOOLCHAIN_DIR:-"$CLOVERROOT"/toolchain}
+  fi
+  export DIR_MAIN=${DIR_MAIN:-"$CLOVERROOT"/toolchain}
 fi
 export TOOLCHAIN_DIR
 echo "TOOLCHAIN_DIR: $TOOLCHAIN_DIR"


### PR DESCRIPTION
Applying this change, nasm and mtoc are moved from $CloverSrc/../opt/local/bin/ to
"~/src/" which is already used by multiple scripts (build*.sh).

I'd like if everything would be stored in $CloverSrc, without touching Users directory,
but I can see why this approach is used.