### PR TITLE
Fix Ubuntu/GCC9 compilation

### DIFF
--- a/Include/Library/HdaModels.h
+++ b/Include/Library/HdaModels.h
@@ -90,7 +90,7 @@ typedef struct {
 //
 // Controller models.
 //
-static HDA_CONTROLLER_LIST_ENTRY gHdaControllerList[] = {
+static const HDA_CONTROLLER_LIST_ENTRY gHdaControllerList[] = {
     //1002  Advanced Micro Devices [AMD] nee ATI Technologies Inc
     { HDA_CONTROLLER(AMD, 0x437b),  L"AMD SB4x0 HD Audio Controller" },
     { HDA_CONTROLLER(AMD, 0x4383),  L"AMD SB600 HD Audio Controller" },
@@ -243,7 +243,7 @@ static HDA_CONTROLLER_LIST_ENTRY gHdaControllerList[] = {
 //
 // Codec models.
 //
-static HDA_CODEC_LIST_ENTRY gHdaCodecList[] = {
+static const HDA_CODEC_LIST_ENTRY gHdaCodecList[] = {
     // AMD.
     { HDA_CODEC(AMD, 0xFFFF),  0x0000, L"AMD (Unknown)" },
 

--- a/rEFIt_UEFI/Platform/hda.c
+++ b/rEFIt_UEFI/Platform/hda.c
@@ -79,7 +79,7 @@ CHAR8 *get_hda_controller_name(UINT16 controller_device_id, UINT16 controller_ve
   static char desc[128];
   UINT32 controller_model = ((controller_device_id << 16) | controller_vendor_id);
 
-  HDA_CONTROLLER_LIST_ENTRY *controller;
+  const HDA_CONTROLLER_LIST_ENTRY *controller;
   for (controller = gHdaControllerList; controller->Id != 0; controller++) {
       // Check ID and revision against array element.
       if (controller->Id == controller_model) {


### PR DESCRIPTION
This resolves `error: 'gHdaCodecList' defined but not used` caused by a patch of mine :scream:.
Not a replacement of my other PR which targeted GCC7