### PR TITLE
Missing EFIAPI

### DIFF
--- a/rEFIt_UEFI/Platform/Platform.h
+++ b/rEFIt_UEFI/Platform/Platform.h
@@ -2349,7 +2349,7 @@ FindDevicePathNodeWithType (
   IN  UINT8                    SubType      OPTIONAL
   );
 
-BOOLEAN IsHDMIAudio(EFI_HANDLE PciDevHandle);
+BOOLEAN EFIAPI IsHDMIAudio(EFI_HANDLE PciDevHandle);
 
 //Parses BootXXXX (XXXX = BootNum) var (from BootOption->Variable) and returns it in BootOption.
 EFI_STATUS

--- a/rEFIt_UEFI/Platform/hda.c
+++ b/rEFIt_UEFI/Platform/hda.c
@@ -113,7 +113,7 @@ UINT32 HDA_IC_sendVerb(EFI_PCI_IO_PROTOCOL *PciIo, UINT32 codecAdr, UINT32 nodeI
 #endif
 
 
-BOOLEAN IsHDMIAudio(EFI_HANDLE PciDevHandle)
+BOOLEAN EFIAPI IsHDMIAudio(EFI_HANDLE PciDevHandle)
 {
   EFI_STATUS          Status;
   EFI_PCI_IO_PROTOCOL *PciIo;


### PR DESCRIPTION
I think there is `EFIAPI` macro missing in `IsHDMIAudio` prototype.