### PR TITLE
Kext loading new structure

### DIFF
--- a/rEFIt_UEFI/Platform/Platform.h
+++ b/rEFIt_UEFI/Platform/Platform.h
@@ -860,7 +860,7 @@ struct SIDELOAD_KEXT {
   SIDELOAD_KEXT  *Next;
   SIDELOAD_KEXT  *PlugInList;
   CHAR16         *FileName;
-  CHAR16         *MatchOS;
+  CHAR16         *KextDirNameUnderOEMPath;
   CHAR16         *Version;
   INPUT_ITEM     MenuItem;
 };

--- a/rEFIt_UEFI/Platform/Settings.c
+++ b/rEFIt_UEFI/Platform/Settings.c
@@ -3463,7 +3463,7 @@ CHAR16* GetBundleVersion(CHAR16 *FullName)
   return CFBundleVersion;
 }
 
-VOID GetListOfInjectKext(CHAR16 *KextPath)
+VOID GetListOfInjectKext(CHAR16 *KextDirNameUnderOEMPath)
 {
 
   REFIT_DIR_ITER  DirIter;
@@ -3471,13 +3471,13 @@ VOID GetListOfInjectKext(CHAR16 *KextPath)
   SIDELOAD_KEXT*  mKext;
   SIDELOAD_KEXT*  mPlugInKext;
   CHAR16*         FullName;
-  CHAR16*         FullPath = PoolPrint(L"%s\\KEXTS\\%s", OEMPath, KextPath);
+  CHAR16*         FullPath = PoolPrint(L"%s\\KEXTS\\%s", OEMPath, KextDirNameUnderOEMPath);
   REFIT_DIR_ITER  PlugInsIter;
   EFI_FILE_INFO   *PlugInEntry;
   CHAR16*         PlugInsPath;
   CHAR16*         PlugInsName;
   BOOLEAN         Blocked = FALSE;
-  if (StrCmp(KextPath, L"Off") == 0) {
+  if (StrCmp(KextDirNameUnderOEMPath, L"Off") == 0) {
     Blocked = TRUE;
   }
 
@@ -3495,7 +3495,7 @@ VOID GetListOfInjectKext(CHAR16 *KextPath)
     mKext = AllocateZeroPool (sizeof(SIDELOAD_KEXT));
     mKext->FileName = PoolPrint(L"%s", DirEntry->FileName);
     mKext->MenuItem.BValue = Blocked;
-    mKext->MatchOS = PoolPrint(L"%s", KextPath);
+    mKext->KextDirNameUnderOEMPath = PoolPrint(L"%s", KextDirNameUnderOEMPath);
     mKext->Next = InjectKextList;
     mKext->Version = GetBundleVersion(FullName);
     InjectKextList = mKext;
@@ -3514,7 +3514,7 @@ VOID GetListOfInjectKext(CHAR16 *KextPath)
       mPlugInKext = AllocateZeroPool(sizeof(SIDELOAD_KEXT));
       mPlugInKext->FileName = PoolPrint(L"%s", PlugInEntry->FileName);
       mPlugInKext->MenuItem.BValue = Blocked;
-      mPlugInKext->MatchOS = PoolPrint(L"%s", KextPath);
+      mPlugInKext->KextDirNameUnderOEMPath = PoolPrint(L"%s", KextDirNameUnderOEMPath);
       mPlugInKext->Next    = mKext->PlugInList;
       mPlugInKext->Version = GetBundleVersion(PlugInsName);
       mKext->PlugInList    = mPlugInKext;

--- a/rEFIt_UEFI/Platform/kext_inject.c
+++ b/rEFIt_UEFI/Platform/kext_inject.c
@@ -467,23 +467,20 @@ EFI_STATUS LoadKexts(IN LOADER_ENTRY *Entry)
 	}
 
 
-  // Add kext from 10.{version}.x
+  // Add kext from 10.{version}
 	{
-		CHAR16 UniOSVersionDotX[16];
-		UnicodeSPrint(UniOSVersionDotX, sizeof(UniOSVersionDotX), L"%a.x", ShortOSVersion);
-
-		CHAR16 OSShortVersionDotXKextsDir[1024];
-		UnicodeSPrint(OSShortVersionDotXKextsDir, sizeof(OSShortVersionDotXKextsDir), L"%s\\kexts\\%s", OEMPath, UniOSVersionDotX);
-		AddKexts(Entry, OSShortVersionDotXKextsDir, UniOSVersionDotX, archCpuType);
+		CHAR16 OSShortVersionKextsDir[1024];
+		UnicodeSPrint(OSShortVersionKextsDir, sizeof(OSShortVersionKextsDir), L"%s\\kexts\\%s", OEMPath, UniShortOSVersion);
+		AddKexts(Entry, OSShortVersionKextsDir, UniShortOSVersion, archCpuType);
 
 		CHAR16 DirName[256];
 		if (OSTYPE_IS_OSX_INSTALLER(Entry->LoaderType)) {
-			UnicodeSPrint(DirName, sizeof(DirName), L"%s_install", UniOSVersionDotX);
+			UnicodeSPrint(DirName, sizeof(DirName), L"%s_install", UniShortOSVersion);
 		} else {
 			if (OSTYPE_IS_OSX_RECOVERY(Entry->LoaderType)) {
-				UnicodeSPrint(DirName, sizeof(DirName), L"%s_recovery", UniOSVersionDotX);
+				UnicodeSPrint(DirName, sizeof(DirName), L"%s_recovery", UniShortOSVersion);
 			}else{
-				UnicodeSPrint(DirName, sizeof(DirName), L"%s_normal", UniOSVersionDotX);
+				UnicodeSPrint(DirName, sizeof(DirName), L"%s_normal", UniShortOSVersion);
 			}
 		}
 		CHAR16 DirPath[1024];
@@ -492,11 +489,15 @@ EFI_STATUS LoadKexts(IN LOADER_ENTRY *Entry)
 	}
 
 		// Add kext from :
-		// 10.{version} if NO minor version
+		// 10.{version}.0 if NO minor version
 		// 10.{version}.{minor version} if minor version is > 0
 	{
 		CHAR16 OSVersionKextsDirName[256];
-		UnicodeSPrint(OSVersionKextsDirName, sizeof(OSVersionKextsDirName), L"%a", Entry->OSVersion);
+		if ( AsciiStrCmp(ShortOSVersion, Entry->OSVersion) == 0 ) {
+			UnicodeSPrint(OSVersionKextsDirName, sizeof(OSVersionKextsDirName), L"%a.0", Entry->OSVersion);
+		}else{
+			UnicodeSPrint(OSVersionKextsDirName, sizeof(OSVersionKextsDirName), L"%a", Entry->OSVersion);
+		}
 
 		CHAR16 DirPath[1024];
 		UnicodeSPrint(DirPath, sizeof(DirPath), L"%s\\kexts\\%s", OEMPath, OSVersionKextsDirName);

--- a/rEFIt_UEFI/refit/menu.c
+++ b/rEFIt_UEFI/refit/menu.c
@@ -4631,7 +4631,7 @@ REFIT_MENU_ENTRY  *SubMenuKextBlockInjection(CHAR16* UniSysVer)
   NewEntry(&Entry, &SubScreen, ActionEnter, SCREEN_KEXT_INJECT, sysVer);
   AddMenuInfoLine(SubScreen, PoolPrint(L"Choose/check kext to disable:"));
   while (Kext) {
-    if (StrStr(Kext->MatchOS, UniSysVer) != NULL) {
+    if (StrStr(Kext->KextDirNameUnderOEMPath, UniSysVer) != NULL) {
       InputBootArgs = AllocateZeroPool(sizeof(REFIT_INPUT_DIALOG));
       InputBootArgs->Entry.Title = PoolPrint(L"%s, v.%s", Kext->FileName, Kext->Version);
       InputBootArgs->Entry.Tag = TAG_INPUT;

--- a/rEFIt_UEFI/refit/menu.c
+++ b/rEFIt_UEFI/refit/menu.c
@@ -4716,39 +4716,38 @@ LOADER_ENTRY *SubMenuKextInjectMgmt(LOADER_ENTRY *Entry)
 			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));
 		}
 
-		// Add kext from 10.{version}.x
+		// Add kext from 10.{version}
 		{
 			CHAR16 DirName[256];
-			UnicodeSPrint(DirName, sizeof(DirName), L"%a.x", ShortOSVersion);
+			UnicodeSPrint(DirName, sizeof(DirName), L"%a", ShortOSVersion);
 			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));
 
 			if (OSTYPE_IS_OSX_INSTALLER(Entry->LoaderType)) {
-				UnicodeSPrint(DirName, sizeof(DirName), L"%a.x_install",
-				        ShortOSVersion);
+				UnicodeSPrint(DirName, sizeof(DirName), L"%a_install", ShortOSVersion);
 			}
 			else {
 				if (OSTYPE_IS_OSX_RECOVERY(Entry->LoaderType)) {
-					UnicodeSPrint(DirName, sizeof(DirName), L"%a.x_recovery",
-					        ShortOSVersion);
+					UnicodeSPrint(DirName, sizeof(DirName), L"%a_recovery", ShortOSVersion);
 				}
 				else {
-					UnicodeSPrint(DirName, sizeof(DirName), L"%a.x_normal",
-					        ShortOSVersion);
+					UnicodeSPrint(DirName, sizeof(DirName), L"%a_normal", ShortOSVersion);
 				}
 			}
 			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));
 		}
 
 		// Add kext from :
-		// 10.{version} if NO minor version
+		// 10.{version}.0 if NO minor version
 		// 10.{version}.{minor version} if minor version is > 0
 		{
 			{
 				CHAR16 OSVersionKextsDirName[256];
-				UnicodeSPrint(OSVersionKextsDirName,
-				        sizeof(OSVersionKextsDirName), L"%a", Entry->OSVersion);
-				AddMenuEntry(SubScreen,
-				        SubMenuKextBlockInjection(OSVersionKextsDirName));
+				if ( AsciiStrCmp(ShortOSVersion, Entry->OSVersion) == 0 ) {
+					UnicodeSPrint(OSVersionKextsDirName, sizeof(OSVersionKextsDirName), L"%a.0", Entry->OSVersion);
+				}else{
+					UnicodeSPrint(OSVersionKextsDirName, sizeof(OSVersionKextsDirName), L"%a", Entry->OSVersion);
+				}
+				AddMenuEntry(SubScreen, SubMenuKextBlockInjection(OSVersionKextsDirName));
 			}
 
 			CHAR16 DirName[256];

--- a/rEFIt_UEFI/refit/menu.c
+++ b/rEFIt_UEFI/refit/menu.c
@@ -2155,6 +2155,8 @@ VOID AddMenuInfoLine(IN REFIT_MENU_SCREEN *Screen, IN CHAR16 *InfoLine)
 
 VOID AddMenuEntry(IN REFIT_MENU_SCREEN *Screen, IN REFIT_MENU_ENTRY *Entry)
 {
+	if ( !Screen ) return;
+	if ( !Entry ) return;
   AddListElement((VOID ***) &(Screen->Entries), (UINTN*)&(Screen->EntryCount), Entry);
 }
 
@@ -4611,27 +4613,30 @@ REFIT_MENU_ENTRY  *SubMenuKextPatches()
 
 REFIT_MENU_ENTRY  *SubMenuKextBlockInjection(CHAR16* UniSysVer)
 {
-  REFIT_MENU_ENTRY     *Entry;
-  REFIT_MENU_SCREEN    *SubScreen;
+  REFIT_MENU_ENTRY     *Entry = NULL;
+  REFIT_MENU_SCREEN    *SubScreen = NULL;
   REFIT_INPUT_DIALOG   *InputBootArgs;
   UINTN i = 0;
   SIDELOAD_KEXT        *Kext = NULL;
-  CHAR8                sysVer[17]; //RehabMan: logic below uses max index of 16, so buffer must be 17
+  CHAR8                sysVer[256];
 
-  UnicodeStrToAsciiStrS(UniSysVer, sysVer, 16);
-  for (i = 0; i < 16; i++) {
+  UnicodeStrToAsciiStrS(UniSysVer, sysVer, sizeof(sysVer));
+  for (i = 0; i < sizeof(sysVer)-2; i++) {
     if (sysVer[i] == '\0') {
       sysVer[i+0] = '-';
       sysVer[i+1] = '>';
+      sysVer[i+2] = '\0';
       break;
     }
   }
 
   Kext = InjectKextList;
-  NewEntry(&Entry, &SubScreen, ActionEnter, SCREEN_KEXT_INJECT, sysVer);
-  AddMenuInfoLine(SubScreen, PoolPrint(L"Choose/check kext to disable:"));
   while (Kext) {
-    if (StrStr(Kext->KextDirNameUnderOEMPath, UniSysVer) != NULL) {
+    if (StrCmp(Kext->KextDirNameUnderOEMPath, UniSysVer) == 0) {
+    	if ( SubScreen == NULL ) {
+    		NewEntry(&Entry, &SubScreen, ActionEnter, SCREEN_KEXT_INJECT, sysVer);
+    		AddMenuInfoLine(SubScreen, PoolPrint(L"Choose/check kext to disable:"));
+    	}
       InputBootArgs = AllocateZeroPool(sizeof(REFIT_INPUT_DIALOG));
       InputBootArgs->Entry.Title = PoolPrint(L"%s, v.%s", Kext->FileName, Kext->Version);
       InputBootArgs->Entry.Tag = TAG_INPUT;
@@ -4657,57 +4662,130 @@ REFIT_MENU_ENTRY  *SubMenuKextBlockInjection(CHAR16* UniSysVer)
     Kext = Kext->Next;
   }
 
-  AddMenuEntry(SubScreen, &MenuEntryReturn);
+  if ( SubScreen != NULL ) AddMenuEntry(SubScreen, &MenuEntryReturn);
   return Entry;
 }
 
 LOADER_ENTRY *SubMenuKextInjectMgmt(LOADER_ENTRY *Entry)
 {
-  LOADER_ENTRY       *SubEntry;
-  REFIT_MENU_SCREEN  *SubScreen;
-  CHAR16             *kextDir = NULL;
-  UINTN              i;
-  CHAR8              ShortOSVersion[8];
-  CHAR16            *UniSysVer = NULL;
-  CHAR8             *ChosenOS =Entry->OSVersion;
+	LOADER_ENTRY       *SubEntry;
+	REFIT_MENU_SCREEN  *SubScreen;
+	CHAR16             *kextDir = NULL;
+	UINTN               i;
+	CHAR8               ShortOSVersion[8];
+	CHAR16             *UniSysVer = NULL;
+	CHAR8              *ChosenOS = Entry->OSVersion;
 
-  NewEntry((REFIT_MENU_ENTRY**)&SubEntry, &SubScreen, ActionEnter, SCREEN_SYSTEM, "Block injected kexts->");
-  SubEntry->Flags = Entry->Flags;
-  if (ChosenOS) {
+	NewEntry((REFIT_MENU_ENTRY**) &SubEntry, &SubScreen, ActionEnter, SCREEN_SYSTEM, "Block injected kexts->");
+	SubEntry->Flags = Entry->Flags;
+	if (ChosenOS) {
 //    DBG("chosen os %a\n", ChosenOS);
-    //shorten os version 10.11.6 -> 10.11
-    for (i = 0; i < 8; i++) {
-      ShortOSVersion[i] = ChosenOS[i];
-      if (ShortOSVersion[i] == '\0') {
-        break;
-      }
-      if (((i > 2) && (ShortOSVersion[i] == '.')) || (i ==  5)) {
-        ShortOSVersion[i] = '\0';
-        break;
-      }
-    }
-    UniSysVer = PoolPrint(L"%a", ShortOSVersion);
+		//shorten os version 10.11.6 -> 10.11
+		for (i = 0; i < 8; i++) {
+			ShortOSVersion[i] = ChosenOS[i];
+			if (ShortOSVersion[i] == '\0') {
+				break;
+			}
+			if (((i > 2) && (ShortOSVersion[i] == '.')) || (i == 5)) {
+				ShortOSVersion[i] = '\0';
+				break;
+			}
+		}
 
-    AddMenuInfoLine(SubScreen, PoolPrint(L"Block injected kexts for target version of macOS: %a", ShortOSVersion));
-    if ((kextDir = GetOSVersionKextsDir(ShortOSVersion)) != NULL) {
-      AddMenuEntry(SubScreen, SubMenuKextBlockInjection(UniSysVer));
-      FreePool(kextDir);
-    }
-    FreePool(UniSysVer);
-  } else {
-    AddMenuInfoLine(SubScreen, PoolPrint(L"Block injected kexts for target version of macOS: %a", ChosenOS));
-  }
-  if ((kextDir = GetOtherKextsDir(TRUE)) != NULL) {
-    AddMenuEntry(SubScreen, SubMenuKextBlockInjection(L"Other"));
-    FreePool(kextDir);
-  }
-  if ((kextDir = GetOtherKextsDir(FALSE)) != NULL) {
-    AddMenuEntry(SubScreen, SubMenuKextBlockInjection(L"Off"));
-    FreePool(kextDir);
-  }
+		AddMenuInfoLine(SubScreen,
+		        PoolPrint(
+		                L"Block injected kexts for target version of macOS: %a",
+		                ShortOSVersion));
 
-  AddMenuEntry(SubScreen, &MenuEntryReturn);
-  return SubEntry;
+		// Add kext from 10.x
+		{
+			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(L"10.x"));
+
+			CHAR16 DirName[256];
+			if (OSTYPE_IS_OSX_INSTALLER(Entry->LoaderType)) {
+				UnicodeSPrint(DirName, sizeof(DirName), L"10.x_install");
+			}
+			else {
+				if (OSTYPE_IS_OSX_RECOVERY(Entry->LoaderType)) {
+					UnicodeSPrint(DirName, sizeof(DirName), L"10.x_recovery");
+				}
+				else {
+					UnicodeSPrint(DirName, sizeof(DirName), L"10.x_normal");
+				}
+			}
+			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));
+		}
+
+		// Add kext from 10.{version}.x
+		{
+			CHAR16 DirName[256];
+			UnicodeSPrint(DirName, sizeof(DirName), L"%a.x", ShortOSVersion);
+			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));
+
+			if (OSTYPE_IS_OSX_INSTALLER(Entry->LoaderType)) {
+				UnicodeSPrint(DirName, sizeof(DirName), L"%a.x_install",
+				        ShortOSVersion);
+			}
+			else {
+				if (OSTYPE_IS_OSX_RECOVERY(Entry->LoaderType)) {
+					UnicodeSPrint(DirName, sizeof(DirName), L"%a.x_recovery",
+					        ShortOSVersion);
+				}
+				else {
+					UnicodeSPrint(DirName, sizeof(DirName), L"%a.x_normal",
+					        ShortOSVersion);
+				}
+			}
+			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));
+		}
+
+		// Add kext from :
+		// 10.{version} if NO minor version
+		// 10.{version}.{minor version} if minor version is > 0
+		{
+			{
+				CHAR16 OSVersionKextsDirName[256];
+				UnicodeSPrint(OSVersionKextsDirName,
+				        sizeof(OSVersionKextsDirName), L"%a", Entry->OSVersion);
+				AddMenuEntry(SubScreen,
+				        SubMenuKextBlockInjection(OSVersionKextsDirName));
+			}
+
+			CHAR16 DirName[256];
+			if (OSTYPE_IS_OSX_INSTALLER(Entry->LoaderType)) {
+				UnicodeSPrint(DirName, sizeof(DirName), L"%a_install",
+				        Entry->OSVersion);
+			}
+			else {
+				if (OSTYPE_IS_OSX_RECOVERY(Entry->LoaderType)) {
+					UnicodeSPrint(DirName, sizeof(DirName), L"%a_recovery",
+					        Entry->OSVersion);
+				}
+				else {
+					UnicodeSPrint(DirName, sizeof(DirName), L"%a_normal",
+					        Entry->OSVersion);
+				}
+			}
+			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));
+		}
+	}
+	else {
+		AddMenuInfoLine(SubScreen,
+		        PoolPrint(
+		                L"Block injected kexts for target version of macOS: %a",
+		                ChosenOS));
+	}
+	if ((kextDir = GetOtherKextsDir(TRUE)) != NULL) {
+		AddMenuEntry(SubScreen, SubMenuKextBlockInjection(L"Other"));
+		FreePool(kextDir);
+	}
+	if ((kextDir = GetOtherKextsDir(FALSE)) != NULL) {
+		AddMenuEntry(SubScreen, SubMenuKextBlockInjection(L"Off"));
+		FreePool(kextDir);
+	}
+
+	AddMenuEntry(SubScreen, &MenuEntryReturn);
+	return SubEntry;
 }
 
 


### PR DESCRIPTION
I'm proposing this PR to solve kext loading issue depending of version and boot mode (normal, recovery, install).
New folder checked for kext is :
    10.x : all versions, all boot modes
    10.x_normal : all version, boot mode "normal", means NOT recovery, NOT install
    10.x_install : all version, installer
    10.x_recovery : all version, recovery

    10.{major version} : all boot mode for this major version
    10.{major version}_normal, _recovery, _install : you understood it now.

    10.{major version}.0 OR 10.{major version}.{minor version} : all boot mode for this particular version.
    add _normal, _recovery, _install : same as before for this particular version.

backward compatibility is preserved because :
  Other is still there, although it's now the same meaning as '10.x' folder
  Folders with a name like '10.13' didn't change meaning.

TODO ? : detect "update boot mode", when OsX reboots just to update itself. No user interaction in this mode. I don't know it it's possible.