### PR TITLE
Rename '10.x' folder

### DIFF
--- a/rEFIt_UEFI/Platform/kext_inject.c
+++ b/rEFIt_UEFI/Platform/kext_inject.c
@@ -445,20 +445,20 @@ EFI_STATUS LoadKexts(IN LOADER_ENTRY *Entry)
   	DBG("GetOtherKextsDir(FALSE) return NULL\n");
   }
 
-  // Add kext from 10.x
+  // Add kext from 10
 	{
 		CHAR16 OSAllVersionKextsDir[1024];
-		UnicodeSPrint(OSAllVersionKextsDir, sizeof(OSAllVersionKextsDir), L"%s\\kexts\\10.x", OEMPath);
-		AddKexts(Entry, OSAllVersionKextsDir, L"10.x", archCpuType);
+		UnicodeSPrint(OSAllVersionKextsDir, sizeof(OSAllVersionKextsDir), L"%s\\kexts\\10", OEMPath);
+		AddKexts(Entry, OSAllVersionKextsDir, L"10", archCpuType);
 
 		CHAR16 DirName[256];
 		if (OSTYPE_IS_OSX_INSTALLER(Entry->LoaderType)) {
-			UnicodeSPrint(DirName, sizeof(DirName), L"10.x_install");
+			UnicodeSPrint(DirName, sizeof(DirName), L"10_install");
 		} else {
 			if (OSTYPE_IS_OSX_RECOVERY(Entry->LoaderType)) {
-				UnicodeSPrint(DirName, sizeof(DirName), L"10.x_recovery");
+				UnicodeSPrint(DirName, sizeof(DirName), L"10_recovery");
 			}else{
-				UnicodeSPrint(DirName, sizeof(DirName), L"10.x_normal");
+				UnicodeSPrint(DirName, sizeof(DirName), L"10_normal");
 			}
 		}
 		CHAR16 DirPath[1024];

--- a/rEFIt_UEFI/refit/menu.c
+++ b/rEFIt_UEFI/refit/menu.c
@@ -4673,6 +4673,7 @@ LOADER_ENTRY *SubMenuKextInjectMgmt(LOADER_ENTRY *Entry)
 	CHAR16             *kextDir = NULL;
 	UINTN               i;
 	CHAR8               ShortOSVersion[8];
+//	CHAR16             *UniSysVer = NULL;
 	CHAR8              *ChosenOS = Entry->OSVersion;
 
 	NewEntry((REFIT_MENU_ENTRY**) &SubEntry, &SubScreen, ActionEnter, SCREEN_SYSTEM, "Block injected kexts->");

--- a/rEFIt_UEFI/refit/menu.c
+++ b/rEFIt_UEFI/refit/menu.c
@@ -4673,7 +4673,6 @@ LOADER_ENTRY *SubMenuKextInjectMgmt(LOADER_ENTRY *Entry)
 	CHAR16             *kextDir = NULL;
 	UINTN               i;
 	CHAR8               ShortOSVersion[8];
-	CHAR16             *UniSysVer = NULL;
 	CHAR8              *ChosenOS = Entry->OSVersion;
 
 	NewEntry((REFIT_MENU_ENTRY**) &SubEntry, &SubScreen, ActionEnter, SCREEN_SYSTEM, "Block injected kexts->");
@@ -4697,20 +4696,20 @@ LOADER_ENTRY *SubMenuKextInjectMgmt(LOADER_ENTRY *Entry)
 		                L"Block injected kexts for target version of macOS: %a",
 		                ShortOSVersion));
 
-		// Add kext from 10.x
+		// Add kext from 10
 		{
-			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(L"10.x"));
+			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(L"10"));
 
 			CHAR16 DirName[256];
 			if (OSTYPE_IS_OSX_INSTALLER(Entry->LoaderType)) {
-				UnicodeSPrint(DirName, sizeof(DirName), L"10.x_install");
+				UnicodeSPrint(DirName, sizeof(DirName), L"10_install");
 			}
 			else {
 				if (OSTYPE_IS_OSX_RECOVERY(Entry->LoaderType)) {
-					UnicodeSPrint(DirName, sizeof(DirName), L"10.x_recovery");
+					UnicodeSPrint(DirName, sizeof(DirName), L"10_recovery");
 				}
 				else {
-					UnicodeSPrint(DirName, sizeof(DirName), L"10.x_normal");
+					UnicodeSPrint(DirName, sizeof(DirName), L"10_normal");
 				}
 			}
 			AddMenuEntry(SubScreen, SubMenuKextBlockInjection(DirName));


### PR DESCRIPTION
Rename '10.x' folder just '10' to be more consistent.

Sorry, the warning breaks the compilation. Fixed.
I didn't change the meaning of the existing folders, so for me, yes, it's compatible.
One thing I didn't think of, because I never used it, is FSInject.efi. (saw that here : https://www.insanelymac.com/forum/topic/282787-clover-v2-instructions/?tab=comments#comment-1853406).
I don't know what it is. I don't think I've ever used it. Is there any kext folder name coded in there ?