### PR TITLE
Display Cover boot volume, Use .VolumeLabel.txt

### DIFF
--- a/rEFIt_UEFI/refit/menu.c
+++ b/rEFIt_UEFI/refit/menu.c
@@ -4214,6 +4214,12 @@ VOID MainMenuStyle(IN REFIT_MENU_SCREEN *Screen, IN SCROLL_STATE *State, IN UINT
       break;
 
     case MENU_FUNCTION_PAINT_ALL:
+    {
+        // Display Clover boot volume
+	CHAR16 line[256];
+	UnicodeSPrint(line, 255, L"Clover booted from %s", SelfVolume->VolName);
+	DrawTextXY(line, 100, 50, X_IS_LEFT);
+    }
       for (i = 0; i <= State->MaxIndex; i++) {
         if (Screen->Entries[i]->Row == 0) {
           if ((i >= State->FirstVisible) && (i <= State->LastVisible)) {


### PR DESCRIPTION
Display Cover boot volume at top right of the screen. Very handy when more than one clover plugged in at boot.
Use .VolumeLabel.txt to create the label of menu items. Instead of "Boot Microsoft from EFI", you can have "Boot Microsoft from HDD1", for example. Alos useful have a better label than Preboot or Recovery.

I used this since quite some time because I often have few hard drives and a lot of partitions.