### PR TITLE
Delete user memory (gRam) when a new config is selected

### DIFF
--- a/rEFIt_UEFI/Platform/Settings.c
+++ b/rEFIt_UEFI/Platform/Settings.c
@@ -5996,6 +5996,16 @@ GetUserSettings(
       Prop = GetProperty(DictPointer, "MemoryRank");
       gSettings.Attribute = (INT8)GetPropertyInteger(Prop, -1); //1==Single Rank, 2 == Dual Rank, 0==undefined -1 == keep as is
 
+      // Delete the user memory when a new config is selected
+      INTN i = 0;
+      for (i = 0; i < gRAM.UserInUse && i < MAX_RAM_SLOTS; i++) {
+        gRAM.User[i].ModuleSize = 0;
+        gRAM.User[i].InUse = 0;
+      }
+      gRAM.UserInUse = 0;
+      gRAM.UserChannels = 0;
+      gSettings.InjectMemoryTables = FALSE;
+
       // Inject memory tables into SMBIOS
       Prop = GetProperty (DictPointer, "Memory");
       if (Prop != NULL){

--- a/rEFIt_UEFI/Platform/kernel_patcher.c
+++ b/rEFIt_UEFI/Platform/kernel_patcher.c
@@ -1818,8 +1818,8 @@ KernelAndKextPatcherInit(IN LOADER_ENTRY *Entry)
 
   // Find kernel Mach-O header:
   // for ML: bootArgs2->kslide + 0x00200000
-  // for older versions: just 0x200000
-  // for AptioFix booting - it's always at KernelRelocBase + 0x200000
+  // for older versions: just 0x00200000
+  // for AptioFix booting - it's always at KernelRelocBase + 0x00200000
   KernelData = (VOID*)(UINTN)(KernelSlide + KernelRelocBase + 0x00200000);
 
   // check that it is Mach-O header and detect architecture

--- a/rEFIt_UEFI/Platform/smbios.c
+++ b/rEFIt_UEFI/Platform/smbios.c
@@ -1295,7 +1295,7 @@ VOID PatchTableType17()
       return;
     }
     // Check channels
-    if ((gRAM.UserChannels == 0) || (gRAM.UserChannels > 4)) {
+    if ((gRAM.UserChannels == 0) || (gRAM.UserChannels > 8)) {
       gRAM.UserChannels = 1;
     }
     if (gRAM.UserInUse >= MAX_RAM_SLOTS) {


### PR DESCRIPTION
Allow more then 4 memory channels: MacPro7,1 has 6 channels, but 8
channels systems exists too

Resolve #43