### PR TITLE
Add missing TgtBridge check in AcpiPatcher::PatchAllTables()

### DIFF
--- a/rEFIt_UEFI/Platform/AcpiPatcher.cpp
+++ b/rEFIt_UEFI/Platform/AcpiPatcher.cpp
@@ -456,10 +456,18 @@ VOID PatchAllTables()
             DBG(" disabled\n");
             continue;
           }
-          Len = FixAny((UINT8*)NewTable, Len,
-                       (const UINT8*)gSettings.PatchDsdtFind[i], gSettings.LenToFind[i],
-                       (const UINT8*)gSettings.PatchDsdtReplace[i], gSettings.LenToReplace[i]);
-          //DBG(" OK\n");
+          if (!gSettings.PatchDsdtTgt[i]) {
+            Len = FixAny((UINT8*)NewTable, Len,
+                         (const UINT8*)gSettings.PatchDsdtFind[i], gSettings.LenToFind[i],
+                         (const UINT8*)gSettings.PatchDsdtReplace[i], gSettings.LenToReplace[i]);
+            //DBG(" OK\n");
+          }else{
+            //DBG("Patching: renaming in bridge\n");
+            Len = FixRenameByBridge2((UINT8*)NewTable, Len,
+				     gSettings.PatchDsdtTgt[i],
+                                     (const UINT8*)gSettings.PatchDsdtFind[i], gSettings.LenToFind[i],
+                                     (const UINT8*)gSettings.PatchDsdtReplace[i], gSettings.LenToReplace[i]);
+          }
         }
       }
       // fixup length and checksum

--- a/rEFIt_UEFI/Platform/FixBiosDsdt.cpp
+++ b/rEFIt_UEFI/Platform/FixBiosDsdt.cpp
@@ -1796,7 +1796,6 @@ UINT32 FixRenameByBridge2 (UINT8* dsdt, UINT32 len, CHAR8* TgtBrgName, const UIN
   BOOLEAN found = FALSE;
   UINT32 i, k;
   UINT32 BrdADR = 0, BridgeSize;
-  UINT32 PCIADR, PCISIZE = 0;
 
   if (!ToFind || !LenTF || !LenTR) {
     DBG(" invalid patches!\n");
@@ -1813,12 +1812,6 @@ UINT32 FixRenameByBridge2 (UINT8* dsdt, UINT32 len, CHAR8* TgtBrgName, const UIN
     DBG(" the patch is too large!\n");
     return len;
   }
-
-  PCIADR = GetPciDevice(dsdt, len);
-  if (PCIADR) {
-    PCISIZE = get_size(dsdt, PCIADR);
-  }
-  if (!PCISIZE) return len; //what is the bad DSDT ?!
 
   DBG("Start ByBridge Rename Fix\n");
   for (i=0x20; len >= 10 && i < len - 10; i++) {

--- a/rEFIt_UEFI/Platform/FixBiosDsdt.cpp
+++ b/rEFIt_UEFI/Platform/FixBiosDsdt.cpp
@@ -1790,7 +1790,7 @@ UINT32 FixAny (UINT8* dsdt, UINT32 len, const UINT8* ToFind, UINT32 LenTF, const
 }
 
 //new method. by goodwin_c
-UINT32 FixRenameByBridge2 (UINT8* dsdt, UINT32 len, CHAR8* TgtBrgName, const UINT8* ToFind, UINT32 LenTF, UINT8* ToReplace, UINT32 LenTR)
+UINT32 FixRenameByBridge2 (UINT8* dsdt, UINT32 len, CHAR8* TgtBrgName, const UINT8* ToFind, UINT32 LenTF, const UINT8* ToReplace, UINT32 LenTR)
 {
   INT32 adr;
   BOOLEAN found = FALSE;
@@ -5352,10 +5352,8 @@ VOID FixBiosDsdt(UINT8* temp, EFI_ACPI_2_0_FIXED_ACPI_DESCRIPTION_TABLE* fadt, C
     //      DBG("Patching: renaming in bridge\n");
           DsdtLen = FixRenameByBridge2(temp, DsdtLen,
                            gSettings.PatchDsdtTgt[i],
-                           (const UINT8*)gSettings.PatchDsdtFind[i],
-                           gSettings.LenToFind[i],
-                           gSettings.PatchDsdtReplace[i],
-                           gSettings.LenToReplace[i]);
+                           (const UINT8*)gSettings.PatchDsdtFind[i], gSettings.LenToFind[i],
+                           (const UINT8*)gSettings.PatchDsdtReplace[i], gSettings.LenToReplace[i]);
 
         }
       } else {

--- a/rEFIt_UEFI/Platform/FixBiosDsdt.h
+++ b/rEFIt_UEFI/Platform/FixBiosDsdt.h
@@ -92,5 +92,17 @@ FixAny (
   );
 
 
+UINT32
+FixRenameByBridge2 (
+  UINT8* dsdt,
+  UINT32 len,
+  CHAR8* TgtBrgName,
+  const UINT8* ToFind,
+  UINT32 LenTF,
+  const UINT8* ToReplace,
+  UINT32 LenTR
+  );
+
+
 
 #endif /* PLATFORM_FIXBIOSDSDT_H_ */


### PR DESCRIPTION
fix unexpected rename in OEM SSDTs when TgtBridge is set, related issue: https://github.com/CloverHackyColor/CloverBootloader/issues/179