### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         uses: ncipollo/release-action@v1
         with:
-          artifacts: *.7z,Clover.app*.pkg,CloverV2*.zip,CLOVERX64.efi.zip,Clover_r*.pkg
+          artifacts: ./*.7z, ./Clover.app*.pkg, ./CloverV2*.zip, ./CLOVERX64.efi.zip, ./Clover_r*.pkg
           bodyFile: ReleaseNotes.md
           name: Release v5.1 r${{ env.CUR_TAG }}
           prerelease: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build-macos:
+    name: Build Clover Release
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Manage Version
+        run: |
+          git fetch --prune --unshallow --tags
+          echo "CUR_TAG=$(git tag -l | tail -1)" >> $GITHUB_ENV
+          echo "GIT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
+      - name: Update CloverHackyColor/OpenCorePkg fork
+        run: git submodule init && git submodule update
+
+      - name: Install Dependencies
+        run: brew install p7zip
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
+          HOMEBREW_NO_AUTO_UPDATE: 1
+
+      - name: Build Clover Pack
+        run: ./buildme "" ci
+
+      - name: Prepare Release Packs
+        run: |
+          (cd "CloverPackage/CloverV2/EFI/CLOVER/" && zip -q "CLOVERX64.efi.zip" "CLOVERX64.efi" || exit 1)
+          (cd "CloverPackage/sym/CloverISO-${{ env.CUR_TAG }}" && 7z a Clover-${{ env.CUR_TAG }}-X64.iso.7z *.iso || exit 1)
+          releaseItems=(CloverPackage/sym/CloverISO*/*.7z CloverPackage/sym/Clover.app*.pkg CloverPackage/sym/CloverV2*.zip CloverPackage/CloverV2/EFI/CLOVER/CLOVERX64.efi.zip CloverPackage/sym/Clover_r*.pkg)
+          for releaseItem in "${releaseItems[@]}"; do cp -Rf "${releaseItem}" ./ || exit 1; done
+
+      - name: Generate Release Notes
+        run: |
+          echo 'The latest ten updates are:' >> ReleaseNotes.md
+          git log -"10" --format="- %H %s" | sed '/^$/d' >> ReleaseNotes.md
+          echo '' >> ReleaseNotes.md
+          /usr/bin/sed -i "" "s:sym/Clover:Clover:g" CloverPackage/sym/Clover*.md5
+          cat CloverPackage/sym/Clover*.md5 >> ReleaseNotes.md
+
+      - name: Upload to Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Clover beta-${{ env.GIT_SHA }}
+          path: |
+            *.7z
+            Clover.app*.pkg
+            CloverV2*.zip
+            CLOVERX64.efi.zip
+            Clover_r*.pkg
+
+      - name: Upload to Release
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: *.7z,Clover.app*.pkg,CloverV2*.zip,CLOVERX64.efi.zip,Clover_r*.pkg
+          bodyFile: ReleaseNotes.md
+          name: Release v5.1 r${{ env.CUR_TAG }}
+          prerelease: false
+          tag: ${{ env.CUR_TAG }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,8 @@ jobs:
 
       - name: Generate Release Notes
         run: |
-          echo 'The latest ten updates are:' >> ReleaseNotes.md
-          git log -"10" --format="- %H %s" | sed '/^$/d' >> ReleaseNotes.md
+          echo "Recent commit descriptions are:" >> ReleaseNotes.md
+          git log $(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))..HEAD --oneline --format=" - %s" | head -10 >> ReleaseNotes.md
           echo '' >> ReleaseNotes.md
           /usr/bin/sed -i "" "s:sym/Clover:Clover:g" CloverPackage/sym/Clover*.md5
           cat CloverPackage/sym/Clover*.md5 >> ReleaseNotes.md

--- a/buildme
+++ b/buildme
@@ -376,10 +376,11 @@ menu
 
 # Main
 set -e
-if [[ "$2" == travis ]]; then
+if [[ "$2" == ci ]]; then
   buildClover
   buildPkg
   buildIso
+  buildApp
 else
   menu
 fi


### PR DESCRIPTION
### Introduction
This PR adds GitHub Actions CI to better check build status for each commit, and help maintainers to control releases easier.

### Functions
- Check build status for each commit and report when build fails
- Also check build status for pull requests
- Provide release for each commit and upload to Actions page
- Collect git history, build the whole Clover pack at the backend, and upload to the release page. Saving time for maintainers to focus on technical part.

### How to trigger Auto-deployment
- GitHub Actions will run after each commit, and generate release if build successes. Users can go to [Actions](https://github.com/CloverHackyColor/CloverBootloader/actions) page to see build detail and download Clover beta version from Artifacts.
<img src="https://user-images.githubusercontent.com/36894554/100946604-c140f100-34d1-11eb-811a-2e6ba6c3222c.jpg" width="500"/>

- The name schema for the Clover beta build is "Clover + beta- + <commit_id>"
- For maintainers, passing a tag to the repository would trigger CI to build the official release. For example
```sh
git tag 5128
git push origin 5128
```
And github-actions will build and release 5128, an example is at [here](https://github.com/stevezhengshiqi/CloverBootloader/releases/tag/5128):
<img src="https://user-images.githubusercontent.com/36894554/100947119-f6017800-34d2-11eb-8449-327080489822.jpg" width="500"/>