### PR TITLE
Opencore 0.6.5 upgrade with latest Clover integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "OpenCorePkg"]
 	path = OpenCorePkg
-	url = https://github.com/serdeliuk/OpenCorePkg
+	url = https://github.com/serdeliuk/OpenCorePkg.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "OpenCorePkg"]
+	url = https://github.com/serdeliuk/OpenCorePkg.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "OpenCorePkg"]
 	url = https://github.com/serdeliuk/OpenCorePkg.git
 	branch = master
+	path = OpenCorePkg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "OpenCorePkg"]
 	path = OpenCorePkg
-	url = https://github.com/CloverHackyColor/OpenCorePkg.git
+	url = https://github.com/serdeliuk/OpenCorePkg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "OpenCorePkg"]
 	url = https://github.com/CloverHackyColor/OpenCorePkg
 	branch = master
-	path = OpenCorePkg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "OpenCorePkg"]
 	url = https://github.com/CloverHackyColor/OpenCorePkg
 	branch = master
+	path = OpenCorePkg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "OpenCorePkg"]
-	url = https://github.com/serdeliuk/OpenCorePkg.git
+	url = https://github.com/CloverHackyColor/OpenCorePkg
 	branch = master
 	path = OpenCorePkg

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "OpenCorePkg"]
-	path = OpenCorePkg
-	url = https://github.com/serdeliuk/OpenCorePkg.git
-	branch = master

--- a/CloverPackage/CloverV2/EFI/CLOVER/config-oc-sample.plist
+++ b/CloverPackage/CloverV2/EFI/CLOVER/config-oc-sample.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>#Sample OC config file</key>
+        <string>by serdeliuk</string>
+
+	<key>Misc</key>
+	<dict>
+		<key>Security</key>
+		<dict>
+			<key>AllowNvramReset</key>
+			<true/>
+			<key>AllowSetDefault</key>
+			<true/>
+			<key>ApECID</key>
+			<integer>0</integer>
+			<key>AuthRestart</key>
+			<false/>
+			<key>BlacklistAppleUpdate</key>
+			<true/>
+			<key>BootProtect</key>
+			<string>None</string>
+			<key>DmgLoading</key>
+			<string>Signed</string>
+			<key>EnablePassword</key>
+			<false/>
+			<key>ExposeSensitiveData</key>
+			<integer>6</integer>
+			<key>HaltLevel</key>
+			<integer>2147483648</integer>
+			<key>PasswordHash</key>
+			<data></data>
+			<key>PasswordSalt</key>
+			<data></data>
+			<key>ScanPolicy</key>
+			<integer>0</integer>
+			<key>SecureBootModel</key>
+			<string>j680</string>
+			<key>Vault</key>
+			<string>Optional</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CloverPackage/CloverV2/EFI/CLOVER/config-oc-sample.plist
+++ b/CloverPackage/CloverV2/EFI/CLOVER/config-oc-sample.plist
@@ -36,7 +36,7 @@
 			<key>ScanPolicy</key>
 			<integer>0</integer>
 			<key>SecureBootModel</key>
-			<string>j680</string>
+			<string>Disabled</string>
 			<key>Vault</key>
 			<string>Optional</string>
 		</dict>

--- a/rEFIt_UEFI/refit.inf
+++ b/rEFIt_UEFI/refit.inf
@@ -529,6 +529,7 @@
   gMsgLogProtocolGuid
   gEfiPlatformDriverOverrideProtocolGuid
   gEmuVariableControlProtocolGuid
+  gEfiAudioDecodeProtocolGuid         # PRODUCES
   gEfiAudioIoProtocolGuid # CONSUMES
   gOcQuirksProtocolGuid
   gAptioMemoryFixProtocolGuid

--- a/rEFIt_UEFI/refit/main.cpp
+++ b/rEFIt_UEFI/refit/main.cpp
@@ -630,7 +630,8 @@ void debugStartImageWithOC()
   EFI_LOADED_IMAGE* OcLoadedImage;
   EFI_STATUS Status = gBS->HandleProtocol(gImageHandle, &gEfiLoadedImageProtocolGuid, (void **) &OcLoadedImage);
   EFI_SIMPLE_FILE_SYSTEM_PROTOCOL* FileSystem = LocateFileSystem(OcLoadedImage->DeviceHandle, OcLoadedImage->FilePath);
-  Status = OcStorageInitFromFs(&mOpenCoreStorage, FileSystem, self.getCloverDirFullPath().wc_str(), NULL);
+//  Status = OcStorageInitFromFs(&mOpenCoreStorage, FileSystem, self.getCloverDirFullPath().wc_str(), NULL);
+  Status = OcStorageInitFromFs(&mOpenCoreStorage, FileSystem, NULL, NULL, self.getCloverDirFullPath().wc_str(), NULL);
 
   Status = ClOcReadConfigurationFile(&mOpenCoreStorage, L"config-oc.plist", &mOpenCoreConfiguration);
   if ( EFI_ERROR(Status) ) panic("ClOcReadConfigurationFile");
@@ -862,7 +863,8 @@ void LOADER_ENTRY::StartLoader()
     EFI_LOADED_IMAGE* OcLoadedImage;
     Status = gBS->HandleProtocol(gImageHandle, &gEfiLoadedImageProtocolGuid, (VOID **) &OcLoadedImage);
     EFI_SIMPLE_FILE_SYSTEM_PROTOCOL* FileSystem = LocateFileSystem(OcLoadedImage->DeviceHandle, OcLoadedImage->FilePath);
-    Status = OcStorageInitFromFs(&mOpenCoreStorage, FileSystem, self.getCloverDirFullPath().wc_str(), NULL);
+//    Status = OcStorageInitFromFs(&mOpenCoreStorage, FileSystem, self.getCloverDirFullPath().wc_str(), NULL);
+    Status = OcStorageInitFromFs(&mOpenCoreStorage, FileSystem, NULL, NULL, self.getCloverDirFullPath().wc_str(), NULL);
 
   /*
    * Define READ_FROM_OC to have mOpenCoreConfiguration initialized from config-oc.plist


### PR DESCRIPTION
@jief666 this upgrade seems to be mandatory in order to be able to boot newer oses with SecureBootModel enabled