### PR TITLE
Fix worklow build clover

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build-macos:
     name: Build Clover Release
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Easy fix because GCC131 will not installed on Sonoma latest, we need to use Ventura latest
GCC131 also failled to installed on Live system Sonoma latest