### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/MdeModulePkg/Universal/RegularExpressionDxe/Oniguruma/regparse.c
+++ b/MdeModulePkg/Universal/RegularExpressionDxe/Oniguruma/regparse.c
@@ -4200,7 +4200,7 @@ fetch_interval_quantifier(UChar** src, UChar* end, PToken* tok, ScanEnv* env)
   if (PEND) goto invalid;
   PFETCH(c);
   if (IS_SYNTAX_OP(env->syntax, ONIG_SYN_OP_ESC_BRACE_INTERVAL)) {
-    if (c != MC_ESC(env->syntax)) goto invalid;
+    if (c != MC_ESC(env->syntax) || PEND) goto invalid;
     PFETCH(c);
   }
   if (c != '}') goto invalid;


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in fetch_interval_quantifier() that was cloned from Oniguruma but did not receive the security patch. The original issue was reported and fixed under https://github.com/kkos/oniguruma/commit/6eb4aca6a7f2f60f473580576d86686ed6a6ebec.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2019-19204
https://github.com/kkos/oniguruma/commit/6eb4aca6a7f2f60f473580576d86686ed6a6ebec