### PR TITLE
Exclude .empty and .DS_Store files in makeV2 and buildpkg

### DIFF
--- a/CloverPackage/makeV2
+++ b/CloverPackage/makeV2
@@ -7,7 +7,8 @@ ROOT="$PWD"
 SYMROOT="${ROOT}"/sym
 REVISION=$(git describe --tags $(git rev-list --tags --max-count=1﻿))
 
-zip -qr CloverV2-${REVISION}.zip CloverV2
+# zip CloverV2, excluding all .empty and all .DS_Store
+zip -qr CloverV2-${REVISION}.zip CloverV2 -x "*/.DS_Store" "*/.empty"
 mv CloverV2-${REVISION}.zip $SYMROOT
 
 open sym

--- a/CloverPackage/makeiso
+++ b/CloverPackage/makeiso
@@ -171,6 +171,7 @@ rm -rf ${IMGROOT}/*/.s*
 rm -rf ${IMGROOT}/*/*/.s*
 rm -rf ${IMGROOT}/*/*/*/.s*
 rm -rf ${IMGROOT}/*/*/*/*/.s*
+find "${IMGROOT}" -name '.DS_Store' -exec rm -R -f {} \; 2>/dev/null
 echo "[HDIUTIL] ${ISOIMAGE}"
 mkdir -p ${SYMROOT}/CloverISO-${REVISION}
 

--- a/CloverPackage/package/buildpkg.sh
+++ b/CloverPackage/package/buildpkg.sh
@@ -265,7 +265,7 @@ addTemplateScripts () {
             echo "Error addTemplateScripts: template '$templateName' doesn't exists" >&2; exit 1; }
 
         # Copy files to destination
-        rsync -pr --exclude=.svn --exclude="*~" "$templateRootDir/" "$pkgRootDir/Scripts/"
+        rsync -pr --exclude=.svn --exclude="*~" --exclude=".DS_Store" "$templateRootDir/" "$pkgRootDir/Scripts/"
     done
 
     files=$( find "$pkgRootDir/Scripts/" -type f )
@@ -524,7 +524,7 @@ main ()
     choiceId="UEFI.only"
     packageRefId=$(getPackageRefId "${packagesidentity}" "${choiceId}")
     mkdir -p ${PKG_BUILD_DIR}/${choiceId}/Root/EFI
-    rsync -r --exclude=.svn --exclude="*~" --exclude='drivers*'   \
+    rsync -r --exclude=.svn --exclude="*~" --exclude='drivers*' --exclude='.empty' --exclude='.DS_Store'   \
      ${SRCROOT}/CloverV2/EFI/BOOT ${PKG_BUILD_DIR}/${choiceId}/Root/EFI/
     addTemplateScripts --pkg-rootdir="${PKG_BUILD_DIR}/${choiceId}" \
                        --subst="INSTALLER_CHOICE=$packageRefId" MarkChoice
@@ -630,9 +630,9 @@ fi
                        --subst="CLOVER_DRIVERS_LEGACY=$DRIVERS_LEGACY" \
                        --subst="CLOVER_DRIVERS_UEFI=$DRIVERS_UEFI" \
                        ${choiceId}
-    rsync -r --exclude=.svn --exclude="*~" --exclude='drivers*'   \
+    rsync -r --exclude=.svn --exclude="*~" --exclude='drivers*' --exclude='.empty' --exclude='.DS_Store'   \
      ${SRCROOT}/CloverV2/EFI/BOOT ${PKG_BUILD_DIR}/${choiceId}/Root/EFI/
-    rsync -r --exclude=.svn --exclude="*~" --exclude='drivers*'   \
+    rsync -r --exclude=.svn --exclude="*~" --exclude='drivers*' --exclude='.empty' --exclude='.DS_Store'   \
      ${SRCROOT}/CloverV2/EFI/CLOVER ${PKG_BUILD_DIR}/${choiceId}/Root/EFI/
 
     # config.plist
@@ -1352,7 +1352,7 @@ if [[ ${NOEXTRAS} != *"Clover Themes"* ]]; then
         local themeName=${themes[$i]##*/}
         [[ -n $(inArray "$themeName" ${specialThemes[@]}) ]] && continue # it is a special theme
         mkdir -p "${PKG_BUILD_DIR}/${themeName}/Root/"
-        rsync -r --exclude=.svn --exclude="*~" "${themes[$i]}/" "${PKG_BUILD_DIR}/${themeName}/Root/${themeName}"
+        rsync -r --exclude=.svn --exclude="*~" --exclude=".DS_Store" "${themes[$i]}/" "${PKG_BUILD_DIR}/${themeName}/Root/${themeName}"
         packageRefId=$(getPackageRefId "${packagesidentity}" "${themeName}")
         addTemplateScripts --pkg-rootdir="${PKG_BUILD_DIR}/${themeName}" \
                            --subst="themeName=$themeName"                \
@@ -1378,7 +1378,7 @@ if [[ ${NOEXTRAS} != *"Clover Themes"* ]]; then
         # Don't add christmas and newyear themes if month < 11
         [[ $currentMonth -lt 11 ]] && [[ "$themeName" == christmas ]] && continue
         mkdir -p "${PKG_BUILD_DIR}/${themeName}/Root/"
-        rsync -r --exclude=.svn --exclude="*~" "$artwork/${specialThemes[$i]}/" "${PKG_BUILD_DIR}/${themeName}/Root/${themeName}"
+        rsync -r --exclude=.svn --exclude="*~" --exclude=".DS_Store" "$artwork/${specialThemes[$i]}/" "${PKG_BUILD_DIR}/${themeName}/Root/${themeName}"
         packageRefId=$(getPackageRefId "${packagesidentity}" "${themeName}")
         addTemplateScripts --pkg-rootdir="${PKG_BUILD_DIR}/${themeName}" \
                            --subst="themeName=$themeName"                \


### PR DESCRIPTION
This PR will keep `.empty` where they are and only exclude them during zip.

Currently, makeV2 will zip the CloverV2 folder that includes .empty under CloverV2/EFI/BOOT and many other folders, resulting sym/CloverV2.zip including all these files
```
./CloverPackage/sym/CloverV2/EFI/CLOVER/misc/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/ACPI/origin/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/ACPI/WINDOWS/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/ACPI/patched/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/10.11/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/Other/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/11/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/10.14/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/10.13/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/10.12/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/10.15/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/12/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/13/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/14/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/kexts/Off/.empty
./CloverPackage/sym/CloverV2/EFI/CLOVER/ROM/.empty
```
Similarly, `.DS_Store` files have to be cleaned.
![Clover_DS_Store](https://github.com/user-attachments/assets/22ba477f-38e2-47c3-a3dd-8792348467b9)
