### PR TITLE
Fix command substitution in revision retrieval

### DIFF
--- a/CloverPackage/makeV2
+++ b/CloverPackage/makeV2
@@ -5,7 +5,7 @@
 cd "$(dirname $([ -L $0 ] && readlink $0 || echo $0))"
 ROOT="$PWD"
 SYMROOT="${ROOT}"/sym
-REVISION=$(git describe --tags $(git rev-list --tags --max-count=1﻿))
+REVISION=$(git describe --tags "$(git rev-list --tags --max-count=1)")
 
 # zip CloverV2, excluding all .empty and all .DS_Store
 zip -qr CloverV2-${REVISION}.zip CloverV2 -x "*/.DS_Store" "*/.empty"


### PR DESCRIPTION
Corrected the command substitution for obtaining the latest tag revision in the makeV2 script by quoting the argument to git describe. This improves compatibility and prevents potential parsing errors.