### PR TITLE
Fixed a regression in the Volume display name function.

### DIFF
--- a/rEFIt_UEFI/Platform/Volume.h
+++ b/rEFIt_UEFI/Platform/Volume.h
@@ -62,7 +62,7 @@ public:
 
   const XStringW getVolLabelOrOSXVolumeNameOrVolName() {
     if ( VolLabel.notEmpty() ) return VolLabel;
-//    if ( osxVolumeName.notEmpty() ) return osxVolumeName;   // not assigned
+    if ( osxVolumeName.notEmpty() ) return osxVolumeName;
     return VolName;
   }
 };

--- a/rEFIt_UEFI/entry_scan/loader.cpp
+++ b/rEFIt_UEFI/entry_scan/loader.cpp
@@ -466,6 +466,7 @@ STATIC XBool isFirstRootUUID(REFIT_VOLUME *Volume) {
 }
 
 // Set Entry->VolName to .disk_label.contentDetails if it exists
+// Set Entry/Volume display name to .disk_label.contentDetails if it exists
 STATIC EFI_STATUS GetOSXVolumeName(LOADER_ENTRY *Entry) {
   EFI_STATUS Status = EFI_NOT_FOUND;
   CONST CHAR16 *targetNameFile =
@@ -476,7 +477,10 @@ STATIC EFI_STATUS GetOSXVolumeName(LOADER_ENTRY *Entry) {
     Status = egLoadFile(Entry->Volume->RootDir, targetNameFile,
                         (UINT8 **)&fileBuffer, &fileLen);
     if (!EFI_ERROR(Status)) {
-      Entry->DisplayedVolName.strncpy(fileBuffer, fileLen);
+      if (Entry->DisplayedVolName.isEmpty()) {
+        Entry->DisplayedVolName.strncpy(fileBuffer, fileLen);
+      }
+      Entry->Volume->osxVolumeName.strncpy(fileBuffer, fileLen);
       DBG("Created name:%ls\n", Entry->DisplayedVolName.wc_str());
 
       FreePool(fileBuffer);


### PR DESCRIPTION
Meaningless gibberish in disk partition titles has been removed.

# Description

Describe in detail what was changed.

## Type of change

- [x] Bugfix
- [ ] New functionality
- [ ] Code improvements
- [ ] Documentation update

## Checklist

- [x] Tested my changes locally
- [ ] Added relevant comments to the code
- [ ] Updated the relevant documentation

## Additional information

In Clover 5168 and later, boot menu entries were not displayed correctly.
