### PR TITLE
Fix UI hang when pressing Space in the main menu.

### DIFF
--- a/rEFIt_UEFI/entry_scan/loader.cpp
+++ b/rEFIt_UEFI/entry_scan/loader.cpp
@@ -1428,7 +1428,7 @@ void LOADER_ENTRY::AddDefaultMenu() {
   UINT64 VolumeSize;
   EFI_GUID Guid;
   XBool KernelIs64BitOnly;
-  XStringW OldOSName{OSName};
+  // XStringW OldOSName{OSName};
 
   constexpr LString8 quietLitteral = "quiet"_XS8;
   constexpr LString8 splashLitteral = "splash"_XS8;
@@ -1628,7 +1628,7 @@ void LOADER_ENTRY::AddDefaultMenu() {
     SubEntry->Title.SWPrintf("Run %ls", FileName.wc_str());
     SubScreen->AddMenuEntry(SubEntry, true);
   }
-  OSName = OldOSName;
+  // OSName = OldOSName;
 }
 
 LOADER_ENTRY *AddLoaderEntry(IN CONST XStringW &LoaderPath,


### PR DESCRIPTION
Fix UI hang when pressing Space in the main menu.

# Description
When pressing the space bar in the main menu, Clover's interface froze completely.

## Type of change

- [x] Bugfix
- [ ] New functionality
- [ ] Code improvements
- [ ] Documentation update

## Checklist

- [x] Tested my changes locally
- [ ] Added relevant comments to the code
- [ ] Updated the relevant documentation

## Additional information

This bug was caused by an incompatibility **`XStringW OldOSName{OSName};`** in GCC 15.2 
