### PR TITLE
This PR addresses the "dead hang" in the Clover UI and fixes the subsequent compilation error.

### DIFF
--- a/rEFIt_UEFI/PlatformEFI/cpp_util/operatorNewDelete.cpp
+++ b/rEFIt_UEFI/PlatformEFI/cpp_util/operatorNewDelete.cpp
@@ -51,6 +51,11 @@ void operator delete  ( void* ptr ) noexcept
   FreePool(ptr);
 }
 
+void operator delete[](void* ptr) noexcept
+{
+  FreePool(ptr);
+}
+
 #ifdef _MSC_VER
 void _cdecl operator delete (void * ptr, unsigned __int64 count)
 #else

--- a/rEFIt_UEFI/PlatformPOSIX+EFI/cpp_util/operatorNewDelete.cpp
+++ b/rEFIt_UEFI/PlatformPOSIX+EFI/cpp_util/operatorNewDelete.cpp
@@ -48,7 +48,12 @@ void operator delete  ( void* ptr ) noexcept
 {
 //  ++operator_delete_count1;
 //  MemLogf(false, 0, "operator delete(%llx) %lld\n", uintptr_t(ptr), operator_delete_count1);
-	return FreePool(ptr);
+	FreePool(ptr);
+}
+
+void operator delete[](void* ptr) noexcept
+{
+  FreePool(ptr);
 }
 
 #ifdef _MSC_VER
@@ -59,7 +64,7 @@ void operator delete (void * ptr, UINTN count)
 {
 //  ++operator_delete_count2;
 //  MemLogf(false, 0, "operator delete(%llx, %lld) %lld\n", uintptr_t(ptr), count, operator_delete_count2);
-  return FreePool(ptr);
+  FreePool(ptr);
 }
 
 

--- a/rEFIt_UEFI/PlatformPOSIX/cpp_util/operatorNewDelete.cpp
+++ b/rEFIt_UEFI/PlatformPOSIX/cpp_util/operatorNewDelete.cpp
@@ -48,7 +48,12 @@ void operator delete  ( void* ptr ) noexcept
 {
 //  ++operator_delete_count1;
 //  MemLogf(false, 0, "operator delete(%llx) %lld\n", uintptr_t(ptr), operator_delete_count1);
-	return FreePool(ptr);
+	FreePool(ptr);
+}
+
+void operator delete[](void* ptr) noexcept
+{
+  FreePool(ptr);
 }
 
 #ifdef _MSC_VER
@@ -59,7 +64,7 @@ void operator delete (void * ptr, UINTN count)
 {
 //  ++operator_delete_count2;
 //  MemLogf(false, 0, "operator delete(%llx, %lld) %lld\n", uintptr_t(ptr), count, operator_delete_count2);
-  return FreePool(ptr);
+  FreePool(ptr);
 }
 
 

--- a/rEFIt_UEFI/cpp_foundation/XStringAbstract.h
+++ b/rEFIt_UEFI/cpp_foundation/XStringAbstract.h
@@ -501,8 +501,9 @@ public:
   }
 
   ThisXStringClass subString(size_t pos, size_t count) const {
-    //		if ( pos > length() ) return ThisXStringClass();
-    //		if ( count > length()-pos ) count = length()-pos;
+    size_t len = length();
+    if (pos >= len || count == 0) return ThisXStringClass();
+    if (count > len - pos) count = len - pos;
 
     ThisXStringClass ret;
 
@@ -1017,7 +1018,7 @@ public:
   ~XStringAbstract() {
     // DBG_XSTRING("Destructor :%ls\n", data());
     if (m_allocatedSize > 0)
-      free((void *)super::__m_data);
+      delete[] super::__m_data;
   }
 
 #ifdef XSTRING_CACHING_OF_SIZE
@@ -1085,10 +1086,13 @@ public:
 #endif
   /* Copy Assign */
   XStringAbstract &operator=(const XStringAbstract &S) {
+    if (this == &S) {
+      return *this;
+    }
     if (S.data() && S.m_allocatedSize == 0) {
       // S points to a litteral
       if (m_allocatedSize > 0) {
-        delete super::__m_data;
+        delete[] super::__m_data;
         m_allocatedSize = 0;
       }
       super::__m_data =
@@ -1106,7 +1110,7 @@ public:
   /* Copy Assign */
   XStringAbstract &operator=(const ls_t &S) {
     if (m_allocatedSize > 0) {
-      delete super::__m_data;
+      delete[] super::__m_data;
       m_allocatedSize = 0;
     }
     super::__m_data = (T *)S.data(); // because it's a litteral, we don't copy.
@@ -1631,7 +1635,7 @@ public:
   /* size is in number of technical chars, NOT in bytes */
   ThisXStringClass &stealValueFrom(T *S, size_t allocatedSize) {
     if (m_allocatedSize > 0)
-      delete super::__m_data;
+      delete[] super::__m_data;
     super::__m_data = S;
 #ifdef XSTRING_CACHING_OF_SIZE
     super::__m_size = utf_size_of_utf_string(super::__m_data, super::__m_data);
@@ -1644,7 +1648,7 @@ public:
   // a future realloc may fail as EDK want the old size.
   ThisXStringClass &stealValueFrom(T *S) {
     if (m_allocatedSize > 0)
-      delete super::__m_data;
+      delete[] super::__m_data;
     super::__m_data = S;
 #ifdef XSTRING_CACHING_OF_SIZE
     super::__m_size = utf_size_of_utf_string(super::__m_data, super::__m_data);
@@ -1657,7 +1661,7 @@ public:
 
   ThisXStringClass &stealValueFrom(ThisXStringClass *S) {
     if (m_allocatedSize > 0)
-      delete super::__m_data;
+      delete[] super::__m_data;
 #ifdef XSTRING_CACHING_OF_SIZE
     super::__m_size = S->size();
 #endif

--- a/rEFIt_UEFI/entry_scan/loader.cpp
+++ b/rEFIt_UEFI/entry_scan/loader.cpp
@@ -1428,7 +1428,6 @@ void LOADER_ENTRY::AddDefaultMenu() {
   UINT64 VolumeSize;
   EFI_GUID Guid;
   XBool KernelIs64BitOnly;
-  // XStringW OldOSName{OSName};
 
   constexpr LString8 quietLitteral = "quiet"_XS8;
   constexpr LString8 splashLitteral = "splash"_XS8;
@@ -1628,7 +1627,6 @@ void LOADER_ENTRY::AddDefaultMenu() {
     SubEntry->Title.SWPrintf("Run %ls", FileName.wc_str());
     SubScreen->AddMenuEntry(SubEntry, true);
   }
-  // OSName = OldOSName;
 }
 
 LOADER_ENTRY *AddLoaderEntry(IN CONST XStringW &LoaderPath,

--- a/rEFIt_UEFI/libeg/XTheme.cpp
+++ b/rEFIt_UEFI/libeg/XTheme.cpp
@@ -867,17 +867,17 @@ const XIcon& XTheme::LoadOSIcon(const XString8& Full)
     DBG("      first=%s\n", First.c_str());
     if (!ReturnIcon->isEmpty()) return *ReturnIcon;
     //else search second name
-    Second = "os_"_XS8 + Full.subString(Comma + 1, Size - Comma - 1);
+    Second = "os_"_XS8 + Full.subString(Comma + 1, MAX_XSIZE);
     //moreover names can be triple L"chrome,grub,linux"
     UINTN SecondComma = Second.indexOf(',');
-    if (Comma == MAX_XSIZE) {
+    if (SecondComma == MAX_XSIZE) {
       ReturnIcon = &GetIcon(Second);
       if (!ReturnIcon->isEmpty()) return *ReturnIcon;
     } else {
       First = Second.subString(0, SecondComma);
       ReturnIcon = &GetIcon(First);
       if (!ReturnIcon->isEmpty()) return *ReturnIcon;
-      Third = "os_"_XS8 + Second.subString(SecondComma + 1, Size - SecondComma - 1);
+      Third = "os_"_XS8 + Second.subString(SecondComma + 1, MAX_XSIZE);
       ReturnIcon = &GetIcon(Third);
       if (!ReturnIcon->isEmpty()) return *ReturnIcon;
     }

--- a/rEFIt_UEFI/refit/main.cpp
+++ b/rEFIt_UEFI/refit/main.cpp
@@ -1686,8 +1686,14 @@ void LOADER_ENTRY::StartLoader()
           (UINT8 *)SysRoot;
 
       size_t i1 = forceKext.rindexOf("\\") + 1;
+      if (i1 == MAX_XSIZE) i1 = 0;
       size_t i2 = forceKext.rindexOf(".");
-      XStringW identifier = forceKext.subString(i1, i2 - i1);
+      XStringW identifier;
+      if (i2 != MAX_XSIZE && i2 > i1) {
+        identifier = forceKext.subString(i1, i2 - i1);
+      } else {
+        identifier = forceKext.subString(i1, MAX_XSIZE);
+      }
       OC_STRING_ASSIGN(
           mOpenCoreConfiguration.Kernel.Force.Values[kextIdx]->Identifier,
           S8Printf("%ls", identifier.wc_str()).c_str());


### PR DESCRIPTION
# Description

The root cause of the hang was:
1. `XStringAbstract::subString` lacked boundary checks, causing huge memory corruption when no delimiter was found.
2. Mixed use of `delete` and `free()` for the same buffer caused heap corruption under GCC 15 optimizations.

3. Added implementation of `operator delete[](void*)` to custom C++ loader runtime wrappers.

## Type of change

- [x] Bugfix
- [ ] New functionality
- [x] Code improvements
- [ ] Documentation update

## Checklist

- [x] Tested my changes locally
- [ ] Added relevant comments to the code
- [ ] Updated the relevant documentation

## Additional information

### INow implemented:
- Robust bounds checking in `XStringAbstract`.
- Unified memory management for `delete[]`.
- Added missing `operator delete[](void*)` to platform wrappers.
