### PR TITLE
Restores the missing log messages for kexts listed in the `KextsToBlock`

### DIFF
--- a/rEFIt_UEFI/refit/main.cpp
+++ b/rEFIt_UEFI/refit/main.cpp
@@ -747,15 +747,23 @@ void LOADER_ENTRY::FilterKextsToBlock() {
   if (gSettings.KernelAndKextPatches.KextsToBlock.isEmpty()) {
     return;
   }
+  DBG("Filtering KextsToBlock:\n");
+  for (size_t i = 0; i < gSettings.KernelAndKextPatches.KextsToBlock.size(); i++) {
+    const char* status = "allowed";
+    if (!gSettings.KernelAndKextPatches.KextsToBlock[i].MenuItem.BValue) {
+      status = "disabled by user";
+    } else if (!gSettings.KernelAndKextPatches.KextsToBlock[i].ShouldBlock(macOSVersion)) {
+      status = "not allowed";
+    }
 
-//  size_t count = gSettings.KernelAndKextPatches.KextsToBlock.size();
-////  size_t entryCount = KernelAndKextPatches.KextsToBlock.size();
-////  size_t count = (settingsCount < entryCount) ? settingsCount : entryCount;
-//
-//  for (size_t i = 0; i < count; ++i) {
-//    gSettings.KernelAndKextPatches.KextsToBlock[i].MenuItem.BValue =
-//        gSettings.KernelAndKextPatches.KextsToBlock[i].MenuItem.BValue;
-//  }
+    DBG(" - [%02zu]: %s :: [OS: %s | MatchOS: %s] ==> %s\n", i,
+        gSettings.KernelAndKextPatches.KextsToBlock[i].Label.c_str(),
+        macOSVersion.asString().c_str(),
+        gSettings.KernelAndKextPatches.KextsToBlock[i].MatchOS.notEmpty()
+            ? gSettings.KernelAndKextPatches.KextsToBlock[i].MatchOS.c_str()
+            : "All",
+        status);
+  }
 }
 
 //
@@ -1994,6 +2002,7 @@ void LOADER_ENTRY::StartLoader()
 
     FilterKextPatches();
     FilterKernelPatches();
+    FilterKextsToBlock();
     FilterBootPatches();
     if (LoadedImage &&
         !BooterPatch((UINT8 *)LoadedImage->ImageBase, LoadedImage->ImageSize)) {


### PR DESCRIPTION
# Description

This change restores the missing log messages for kexts listed in the `KextsToBlock` section of `config.plist`. Users noticed that messages like "Allow IOSkywalk Downgrade" (which is a comment label for blocking `com.apple.iokit.IOSkywalkFamily`) were no longer appearing in `bdmesg`.

The implementation iterates through the `KextsToBlock` array, evaluates whether each entry should be active based on user settings and macOS version compatibility, and logs the result using the `DBG` macro. This logging mirrors the behavior of other patch types in Clover, providing transparency into which kexts are being blocked during the boot process without affecting the actual blocking logic.

Describe in detail what was changed.

## Type of change

- [ ] Bugfix
- [x] New functionality
- [ ] Code improvements
- [ ] Documentation update

## Checklist

- [x] Tested my changes locally
- [ ] Added relevant comments to the code
- [ ] Updated the relevant documentation

## Additional information

Include any extra details relevant to your PR.
