### PR TITLE
Simplify the package choice declaration

### DIFF
--- a/CloverPackage/package/Scripts.templates/CloverLogoutHook/preinstall
+++ b/CloverPackage/package/Scripts.templates/CloverLogoutHook/preinstall
@@ -20,7 +20,7 @@ DEST_VOL="${3}"
 EFI_ROOT_DIR=$(cd "${DEST_VOL}"/Private/tmp/EFIROOTDIR; pwd -P)
 CLOVER_INSTALLER_PLIST_NEW="${DEST_VOL}@CLOVER_INSTALLER_PLIST_NEW@"
 install_log="${DEST_VOL}/Private/tmp/Clover_Install_Log.txt"
-installer_choice="@INSTALLER_CHOICE@"
+installer_choice="org.clover.cloverlogouthook"
 
 echo "====================================================="
 echo " "

--- a/CloverPackage/package/Scripts.templates/CloverLogoutHook/preinstall
+++ b/CloverPackage/package/Scripts.templates/CloverLogoutHook/preinstall
@@ -20,7 +20,7 @@ DEST_VOL="${3}"
 EFI_ROOT_DIR=$(cd "${DEST_VOL}"/Private/tmp/EFIROOTDIR; pwd -P)
 CLOVER_INSTALLER_PLIST_NEW="${DEST_VOL}@CLOVER_INSTALLER_PLIST_NEW@"
 install_log="${DEST_VOL}/Private/tmp/Clover_Install_Log.txt"
-installer_choice="org.clover.cloverlogouthook"
+installer_choice="@INSTALLER_CHOICE@"
 
 echo "====================================================="
 echo " "

--- a/CloverPackage/package/buildpkg.sh
+++ b/CloverPackage/package/buildpkg.sh
@@ -1258,8 +1258,8 @@ fi
     addTemplateScripts --pkg-rootdir="${PKG_BUILD_DIR}/${choiceId}" ${choiceId}   
     packageRefId=$(getPackageRefId "${packagesidentity}" "${choiceId}")
     buildpackage "$packageRefId" "${choiceId}" "${PKG_BUILD_DIR}/${choiceId}" "/"
-    addChoice  --start-visible="true" --title="CloverLogoutHook" --description="CloverLogoutHook for Clover Legacy Boot" --start-selected="false"  --pkg-refs="$packageRefId" "${choiceId}"
-
+    addChoice --start-visible="true" --start-selected="false"  \
+              --pkg-refs="$packageRefId" "${choiceId}"
 # End build CloverLogoutHook package
 
 # build rc scripts package


### PR DESCRIPTION
This pull request makes minor adjustments to the CloverLogoutHook packaging process, focusing on simplifying configuration and installer choice presentation.

Describe in detail what was changed.

## Type of change

- [ ] Bugfix
- [ ] New functionality
- [ ] Code improvements
- [ ] Documentation update

## Checklist

- [ ] Tested my changes locally
- [ ] Added relevant comments to the code
- [ ] Updated the relevant documentation

## Additional information

Include any extra details relevant to your PR.
This pull request makes minor adjustments to the CloverLogoutHook packaging process, primarily focusing on simplifying configuration and installer choice metadata.

- **Installer UI metadata:**
  * The `addChoice` call in `buildpkg.sh` for the CloverLogoutHook package no longer specifies a title or description, simplifying the installer options presented to the user.